### PR TITLE
Use blob storage for indexedDB (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,19 +131,21 @@ I have compared the performance & stability of `Filesystem.writeFile` with `writ
 - [1] Crashes the WKWebView, which immediately reloads the page
 - [2] `Failed to load resource: WebKit encountered an internal error`
 
-### Google Chrome (MacBook Pro 2012)
-The plugin falls back to `Filesystem.appendFile` in the browser, so these results should be approximately equal.
+### Google Chrome (Desktop FX-4350)
+The plugin puts your blob directly[1][2] into indexedDB storage if your browser supports that, otherwise it falls back to `Filesystem.appendFile`.
 
 | Size          | Filesystem       | BlobWriter          |
 |---------------|------------------|---------------------|
-| 1 kilobyte    | 46ms             | 45ms                |
-| 1 megabyte    | 113ms            | 105ms               |
-| 8 megabytes   | 1.5s             | 1.3s                |
-| 32 megabytes  | 6.7s             | 5.9s                |
-| 64 megabytes  | 12.5s            | 16.7s               |
-| 512 megabytes | Error[1]         | Error[1]            |
+| 1 kilobyte    | 4ms              | 9ms                 |
+| 1 megabyte    | 180ms            | 16ms                |
+| 8 megabytes   | 1.5s             | 43ms                |
+| 32 megabytes  | 5.2s             | 141ms               |
+| 64 megabytes  | 10.5s            | 0.2s                |
+| 512 megabytes | Error[3]         | 1.1s                |
 
-- [1] `DOMException: The serialized keys and/or value are too large`
+- [1] Data returned from `Filesystem.readFile` is your pure blob (not base64 encoded)
+- [2] The returned uri is created with `URL.createObjectURL` from your blob (e.g. `blob:http://localhost/189603f7-b6e7-40f2-92e4-466dc875633b`)
+- [3] `DOMException: The serialized keys and/or value are too large`
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # capacitor-blob-writer
-A faster, more stable alternative to @capacitor/filesystem's `Filesystem.writeFile` for writing Blobs to the filesystem. While the plugin may be used by all platforms for improved stability, only iOS and Android benefit from significantly faster writes.
+A faster, more stable alternative to @capacitor/filesystem's `Filesystem.writeFile` for writing Blobs to the filesystem.
 
 ## Usage
 ```javascript
@@ -49,13 +49,37 @@ write_blob({
     on_fallback(error) {
         console.error(error);
     }
-}).then(function (my_video_uri) {
+}).then(async function () {
 
-// You can make use of the new file's URI immediately.
+// Obtain the URI for your platform
 
-  const video_element = document.createElement("video");
-  video_element.src = Capacitor.convertFileSrc(my_video_uri);
-  document.body.appendChild(video_element);
+    let my_video_uri;
+    if (Capacitor.getPlatform() == "web") {
+        const { data } = await Filesystem.readFile({ path, directory })
+        my_video_uri = URL.createObjectURL(data)
+    } else {
+        const { uri } = await Filesystem.getUri({ path, directory })
+        my_video_uri = Capacitor.convertFileSrc(uri)
+    }
+
+// Now you can use it in your video element
+
+    const video_element = document.createElement("video");
+    video_element.src = Capacitor.convertFileSrc(my_video_uri);
+    document.body.appendChild(video_element);
+
+// Do not forget to revoke the uri when you are done with it!
+// This is important to avoid memory leaks!
+
+    video_element.onended = function () {
+
+// The platform check is optional since browsers do not complain
+// when an invalid uri is provided.
+
+        if (Capacitor.getPlatform() == "web") {
+            URL.revokeObjectURL(my_video_uri);
+        }
+    }
 });
 ```
 
@@ -89,16 +113,23 @@ Configure `AndroidManifest.xml` to [allow cleartext](https://github.com/diachede
 ```
 
 ## How it works
+### Web
+For the web platform the plugin creates an empty indexedDB entry with `Filesystem.writeFile`. Then it replaces it's size and content with the provided blob, completely avoiding base64 encoding. Therefore, significantly improving the writing speed.
+
+There is a caveat though. If you use `Filesystem.readFile`, you will get a **Blob** as your data back instead of a base64 **string**, since your data has never been encoded in the first place.
+
+### iOS / Android
 When the plugin is loaded, an HTTP server is started on a random port, which streams authenticated PUT requests to disk, then moves them into place. The `write_blob` function makes the actual `fetch` call and handles the necessary authentication. Because browsers are highly optimised for network operations, this write does not block the UI.
 
 I had dreamed of having the WebView intercept the PUT request and write the request's body to disk. Incredibly, neither iOS nor Android's webview are capable of correctly reading request bodies, due to [this](https://issuetracker.google.com/issues/36918490) and [this](https://bugs.webkit.org/show_bug.cgi?id=179077). Hence an actual webserver will be required for the forseeable future.
 
-### Fallback mode
+### Fallback mode (iOS / Android)
 There are times when `write_blob` inexplicably fails to communicate with the webserver, or the webserver fails to write the file. A fallback mode is provided, which invokes an alternative strategy if an error occurs. In fallback mode, the Blob is split into chunks and serially concatenated on disk using `Filesystem.appendFile`. While slower than `Filesystem.writeFile`, this strategy avoids Base64-encoding the entire Blob at once, making it stable for large Blobs.
 
 ## Known limitations & issues
 - potential security risk (only as secure as [GCDWebServer](https://github.com/swisspol/GCDWebServer)/[nanohttpd](https://github.com/NanoHttpd/nanohttpd)), and also #12
 - no `append` option yet (see #11)
+- developers have to handle the URIs for different platforms themselves (see [example](#usage))
 
 ## Benchmarks
 I have compared the performance & stability of `Filesystem.writeFile` with `write_blob` on my devices, see `demo/src/index.ts` for more details.
@@ -132,7 +163,7 @@ I have compared the performance & stability of `Filesystem.writeFile` with `writ
 - [2] `Failed to load resource: WebKit encountered an internal error`
 
 ### Google Chrome (Desktop FX-4350)
-The plugin puts your blob directly[1][2] into indexedDB storage if your browser supports that, otherwise it falls back to `Filesystem.appendFile`.
+The plugin puts your blob directly[1] into the indexedDB storage.
 
 | Size          | Filesystem       | BlobWriter          |
 |---------------|------------------|---------------------|
@@ -141,11 +172,10 @@ The plugin puts your blob directly[1][2] into indexedDB storage if your browser 
 | 8 megabytes   | 1.5s             | 43ms                |
 | 32 megabytes  | 5.2s             | 141ms               |
 | 64 megabytes  | 10.5s            | 0.2s                |
-| 512 megabytes | Error[3]         | 1.1s                |
+| 512 megabytes | Error[2]         | 1.1s                |
 
 - [1] Data returned from `Filesystem.readFile` is your pure blob (not base64 encoded)
-- [2] The returned uri is created with `URL.createObjectURL` from your blob (e.g. `blob:http://localhost/189603f7-b6e7-40f2-92e4-466dc875633b`)
-- [3] `DOMException: The serialized keys and/or value are too large`
+- [2] `DOMException: The serialized keys and/or value are too large`
 
 ## Changelog
 

--- a/blob_writer.js
+++ b/blob_writer.js
@@ -1,4 +1,4 @@
-/*jslint browser */
+/*jslint browser this */
 import {Capacitor, registerPlugin} from "@capacitor/core";
 import {Filesystem} from "@capacitor/filesystem";
 
@@ -47,50 +47,59 @@ function append_blob(directory, path, blob) {
 }
 
 function update_blob_content(directory, relative, blob) {
-	const indexedDB = window.indexedDB ||
-        window.mozIndexedDB ||
-        window.webkitIndexedDB ||
-        window.msIndexedDB;
 
-	return new Promise((resolve, reject) => {
-		const connection = indexedDB.open("Disc");
-		const fail = ({ target }) => reject(target);
+    return new Promise(function (resolve, reject) {
+        function fail() {
+            reject(this.error);
+        }
 
-		connection.onerror = fail;
-		connection.onsuccess = ({ target }) => {
-			const db = target.result;
+        const connection = window.indexedDB.open("Disc");
+        connection.onerror = fail;
+        connection.onsuccess = function () {
+            const db = connection.result;
 
-			const transaction = db.transaction("FileStorage", "readwrite");
-			transaction.onerror = fail;
+            const transaction = db.transaction("FileStorage", "readwrite");
+            transaction.onerror = fail;
 
-			const store = transaction.objectStore("FileStorage");
-			const path = `/${directory}/${relative.replace(/^\//, "")}`;
+            const store = transaction.objectStore("FileStorage");
+            const path = `/${directory}/${relative.replace(/^\//, "")}`;
 
-			const request = store.get(path);
-			request.onerror = fail;
-			request.onsuccess = ({ target }) => {
-				const request = store.put({
-					...target.result,
-					size: blob.size,
-					content: blob,
-				});
-				request.onerror = fail;
-				request.onsuccess = () => {
-					const request = store.get(path);
-					request.onerror = fail;
-					request.onsuccess = (event) => {
-						const { target } = event;
-						if (!target) fail(event);
-						const { result } = target;
-						if (!result) fail(event);
-						const { content } = result;
-						if (!content) fail(event);
-						return resolve(URL.createObjectURL(content));
-					};
-				};
-			};
-		};
-	});
+            const load = store.get(path);
+            load.onerror = fail;
+            load.onsuccess = function () {
+                const put = store.put(Object.assign(load.result, {
+                    size: blob.size,
+                    content: blob
+                }));
+                put.onerror = fail;
+                put.onsuccess = function () {
+                    resolve(undefined);
+                };
+            };
+        };
+    });
+}
+
+function write_file_via_indexeddb({
+    path,
+    directory,
+    blob,
+    recursive
+}) {
+
+// Firstly, create the file entry in the database.
+
+    return Filesystem.writeFile({
+        directory,
+        path,
+        recursive,
+        data: ""
+    }).then(function () {
+
+// Now update the content of the file entry
+
+        return update_blob_content(directory, path, blob);
+    });
 }
 
 function write_file_via_bridge({
@@ -107,15 +116,12 @@ function write_file_via_bridge({
         path,
         recursive,
         data: ""
-    }).then(function ({uri}) {
-        return update_blob_content(directory, path, blob).catch(async () => {
-            console.warn("Unable to set blob content. Using base64 fallback...");
+    }).then(function () {
 
 // Now write the file incrementally so we do not exceed our memory limits when
 // attempting to Base64 encode the entire Blob at once.
-            await append_blob(directory, path, blob);
-            return uri;
-        });
+
+        return append_blob(directory, path, blob);
     });
 }
 
@@ -127,8 +133,8 @@ function write_blob(options) {
         recursive,
         on_fallback
     } = options;
-    if (Capacitor.platform !== "ios" && Capacitor.platform !== "android") {
-        return write_file_via_bridge(options);
+    if (Capacitor.getPlatform() === "web") {
+        return write_file_via_indexeddb(options);
     }
     return Promise.all([
         BlobWriter.get_config(),


### PR DESCRIPTION
## Fixes #42

Now `capacitor-blob-writer` stores actuals blobs in IndexedDB on the web platform, instead of converting them to base64 strings. Also `write_blob` function returns a valid URL for the web environment (now the README example actually works in a browser).

All the tests in the demo app have passed unchanged (tested web only):
```
starting tests
wrote 10 bytes in 76ms
wrote 10 bytes in 18ms
wrote 10 bytes in 9ms
wrote 10 bytes in 22ms
wrote 10 bytes in 14ms
wrote 10 bytes in 15ms
wrote 10 bytes in 25ms
wrote 10 bytes in 32ms
wrote 10 bytes in 41ms
wrote 5242880 bytes in 19ms
tests passed!
```

Docs and benchmarks have been updated accordingly. The performance gains are quite impressive! It even managed to save a **512 MB** file!
| Size          | Filesystem       | BlobWriter          |
|---------------|------------------|---------------------|
| 1 kilobyte    | 4ms              | 9ms                 |
| 1 megabyte    | 180ms            | 16ms                |
| 8 megabytes   | 1.5s             | 43ms                |
| 32 megabytes  | 5.2s             | 141ms               |
| 64 megabytes  | 10.5s            | 0.2s                |
| 512 megabytes | Error[3]         | 1.1s                |

This implementation does not remove the previous one, but uses it as a fallback. You might consider removing `Filesystem.appendFile` version entirely since blobs in IDB are widely supported now ([in chrome since 2014](https://developer.chrome.com/blog/blob-support-for-Indexeddb-landed-on-chrome-dev/)). Anyway, this decision is up to you.

Also this might be considered a breaking change since `Filesystem.readFile` now returns a blob instead of a string. So, the package should be versioned appropriately.