### PR TITLE
Properly reference typedefs in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "main": "blob_writer.umd.js",
     "module": "blob_writer.js",
     "exports": {
-        ".": "./blob_writer.js",
-        "./package.json": "./package.json",
-        "./definitions.d.ts": "./definitions.d.ts"
+        ".": {
+            "default": "./blob_writer.js",
+            "types": "./definitions.d.ts"
+        },
+        "./package.json": "./package.json"
     },
     "types": "definitions.d.ts",
     "files": [


### PR DESCRIPTION
I am getting Typescript errors saying: 
```
Could not find a declaration file for module 'capacitor-blob-writer'. '<app>/node_modules/capacitor-blob-writer/blob_writer.js' implicitly has an 'any' type.
  There are types at '<app>/node_modules/capacitor-blob-writer/definitions.d.ts', but this result could not be resolved when respecting package.json "exports". The 'capacitor-blob-writer' library may need to update its package.json or typings.ts(7016)

```

I believe the typedefs need to be referenced differently and have updated them as such. I tried this locally and it works for me this way